### PR TITLE
Add ingressClassName to ingress.yml files

### DIFF
--- a/etc/k8s/helm-chart/eventhub/charts/account/templates/account-ingress.yaml
+++ b/etc/k8s/helm-chart/eventhub/charts/account/templates/account-ingress.yaml
@@ -11,6 +11,7 @@ metadata:
     nginx.ingress.kubernetes.io/configuration-snippet: |
       more_set_input_headers "from-ingress: true";
 spec:
+  ingressClassName: nginx
   tls:
   - hosts:
       - {{ .Values.global.accountDomain }}

--- a/etc/k8s/helm-chart/eventhub/charts/admin-api/templates/admin-api-ingress.yaml
+++ b/etc/k8s/helm-chart/eventhub/charts/admin-api/templates/admin-api-ingress.yaml
@@ -9,6 +9,7 @@ metadata:
     nginx.ingress.kubernetes.io/proxy-buffers-number: "{{ .Values.global.nginxProxyBuffersNumber }}"
     cert-manager.io/cluster-issuer: letsencrypt
 spec:
+  ingressClassName: nginx
   tls:
   - hosts:
       - {{ .Values.global.adminApiDomain }}

--- a/etc/k8s/helm-chart/eventhub/charts/admin/templates/admin-ingress.yaml
+++ b/etc/k8s/helm-chart/eventhub/charts/admin/templates/admin-ingress.yaml
@@ -11,6 +11,7 @@ metadata:
     nginx.ingress.kubernetes.io/configuration-snippet: |
       more_set_headers "blazor-environment: {{ .Values.global.dotnetEnvironment }}";
 spec:
+  ingressClassName: nginx
   tls:
   - hosts:
       - {{ .Values.global.adminDomain }}

--- a/etc/k8s/helm-chart/eventhub/charts/api/templates/api-ingress.yaml
+++ b/etc/k8s/helm-chart/eventhub/charts/api/templates/api-ingress.yaml
@@ -9,6 +9,7 @@ metadata:
     nginx.ingress.kubernetes.io/proxy-buffers-number: "{{ .Values.global.nginxProxyBuffersNumber }}"
     cert-manager.io/cluster-issuer: letsencrypt
 spec:
+  ingressClassName: nginx
   tls:
   - hosts:
       - {{ .Values.global.apiDomain }}

--- a/etc/k8s/helm-chart/eventhub/charts/www/templates/www-ingress.yaml
+++ b/etc/k8s/helm-chart/eventhub/charts/www/templates/www-ingress.yaml
@@ -12,6 +12,7 @@ metadata:
 {{- end }}
     cert-manager.io/cluster-issuer: letsencrypt
 spec:
+  ingressClassName: nginx
   tls:
   - hosts:
       - {{ .Values.global.wwwDomain }}


### PR DESCRIPTION
In the newer version of ingress controller, domain can't ve resolved and redirected to pod.

Adding this declaration solves the issue 